### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/liamwh/surreal-id/compare/v0.1.0...v0.1.1) - 2023-09-22
+
+### Other
+- Loosen interface, additional proptests
+- Improve example
+- Whitespacing
+- Updated readme

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,7 +2871,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "surreal-id"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surreal-id"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A package for easily creating ID types for usage with surrealdb"


### PR DESCRIPTION
## 🤖 New release
* `surreal-id`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/liamwh/surreal-id/compare/v0.1.0...v0.1.1) - 2023-09-22

### Other
- Loosen interface, additional proptests
- Improve example
- Whitespacing
- Updated readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).