### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/liamwh/surreal-id/compare/v0.2.1...v0.2.2) - 2024-01-26
+
+### Other
+- Add cargo-deny and cargo-audit
+
 ## [0.2.1](https://github.com/liamwh/surreal-id/compare/v0.2.0...v0.2.1) - 2023-10-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,7 +3099,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "surreal-id"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surreal-id"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A package for easily creating ID types for usage with surrealdb"


### PR DESCRIPTION
## 🤖 New release
* `surreal-id`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/liamwh/surreal-id/compare/v0.2.1...v0.2.2) - 2024-01-26

### Other
- Add cargo-deny and cargo-audit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).