### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/liamwh/surreal-id/compare/v1.0.0...v1.0.1) - 2024-09-14
+
+### Fixed
+
+- update time
+
+### Other
+
+- *(deps)* bump proptest from 1.3.1 to 1.5.0
+- Make dependabot use conventional commits
+- Bump tokio from 1.32.0 to 1.35.0
+- *(deps)* bump thiserror from 1.0.53 to 1.0.55
+- *(deps)* bump surrealdb from 1.0.0 to 1.0.2
+- Bump thiserror from 1.0.49 to 1.0.53
+- Bump serde from 1.0.188 to 1.0.193
+
 ## [0.2.2](https://github.com/liamwh/surreal-id/compare/v0.2.1...v0.2.2) - 2024-01-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "surreal-id"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surreal-id"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A package for easily creating ID types for usage with surrealdb"


### PR DESCRIPTION
## 🤖 New release
* `surreal-id`: 1.0.0 -> 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/liamwh/surreal-id/compare/v1.0.0...v1.0.1) - 2024-09-14

### Fixed

- update time

### Other

- *(deps)* bump proptest from 1.3.1 to 1.5.0
- Make dependabot use conventional commits
- Bump tokio from 1.32.0 to 1.35.0
- *(deps)* bump thiserror from 1.0.53 to 1.0.55
- *(deps)* bump surrealdb from 1.0.0 to 1.0.2
- Bump thiserror from 1.0.49 to 1.0.53
- Bump serde from 1.0.188 to 1.0.193
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).